### PR TITLE
Add clangd (LSP) specific files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ DoxyWarnings.log
 .settings
 .pydevproject
 .vscode
+/.clangd/
+/compile_commands.json
 
 .build/
 build-dir/


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `.clangd` and `compile_commands.json` files for clang based LSP to gitignore.

ENDRELEASENOTES
