### PR TITLE
Use k4run in key4hep environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ make install
 
 
 ```
-./run gaudirun.py ../k4TestFWCore/options/createHelloWorld.py 
+k4run ../k4TestFWCore/options/createHelloWorld.py 
 
-./run gaudirun.py ../k4TestFWCore/options/createExampleEventData.py 
+k4run ../k4TestFWCore/options/createExampleEventData.py 
 
 ```
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `k4run` in the README instead of the Gaudi based `./run gaudirun.py`

ENDRELEASENOTES

@andresailer do we run doctests on this one? If not should we add them?
