### PR TITLE
Fix example to work with Frame based DataSvc

### DIFF
--- a/k4ProjectTemplate/src/components/CreateExampleEventData.cpp
+++ b/k4ProjectTemplate/src/components/CreateExampleEventData.cpp
@@ -22,11 +22,9 @@ StatusCode CreateExampleEventData::initialize() {
 }
 
 StatusCode CreateExampleEventData::execute() {
-  m_singleIntHandle.put(new int(12345));
-
-  std::vector<float>* floatVector = m_vectorFloatHandle.createAndPut();
-  floatVector->emplace_back(125.);
-  floatVector->emplace_back(25.);
+  auto* floatVector = m_vectorFloatHandle.createAndPut();
+  floatVector->push_back(125.);
+  floatVector->push_back(25.);
 
   edm4hep::MCParticleCollection* particles = m_mcParticleHandle.createAndPut();
 

--- a/k4ProjectTemplate/src/components/CreateExampleEventData.h
+++ b/k4ProjectTemplate/src/components/CreateExampleEventData.h
@@ -4,6 +4,8 @@
 // GAUDI
 #include "GaudiAlg/GaudiAlgorithm.h"
 
+#include "podio/UserDataCollection.h"
+
 // edm4hep
 #include "TTree.h"
 #include "k4FWCore/DataHandle.h"
@@ -48,8 +50,6 @@ private:
   /// Handle for the genvertices to be written
   DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHit", Gaudi::DataHandle::Writer, this};
 
-  DataHandle<float>              m_singleFloatHandle{"SingleFloat", Gaudi::DataHandle::Writer, this};
-  DataHandle<std::vector<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer, this};
-  DataHandle<int>                m_singleIntHandle{"SingleInt", Gaudi::DataHandle::Writer, this};
+  DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer, this};
 };
 #endif /* TESTFWCORE_CREATEEXAMPLEEVENTDATA */


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the examples to work with the Frame based `PodioDataSvc` that is introduced with key4hep/k4FWCore#100

ENDRELEASENOTES
