### PR TITLE
Update algorithms and README, don't link to GaudiAlgLib, update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # k4-project-template
 
 
-This repository can be a starting point and template for projects using the Key4HEP software stack.
+This repository can be a starting point and template for projects using the Key4hep software stack, in particular those writing Gaudi algorithms.
 
 
 ## Dependencies
@@ -16,13 +16,15 @@ This repository can be a starting point and template for projects using the Key4
 
 ## Installation
 
+Run, from the `k4-project-template` directory:
 
 ``` bash
 source /cvmfs/sw.hsf.org/key4hep/setup.sh
-mkdir build install
-cd build;
-cmake .. -DCMAKE_INSTALL_PREFIX=../install
-make install
+k4_local_repo
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=../install -G Ninja
+ninja install
 ```
 
 Alternatively you can source the nightlies instead of the releases:
@@ -48,7 +50,8 @@ issue](https://github.com/key4hep/k4-project-template/issues/new/choose).
 ## Execute Examples
 
 Make sure that `../install/lib` and `../install/python` are in `LD_LIBRARY_PATH`
-and `PYTHONPATH` respectively, by doing:
+and `PYTHONPATH` respectively (`k4_local_repo` should take care of this).
+If they are not, they can be added by running:
 ``` bash
 export LD_LIBRARY_PATH=$PWD/../install/lib:$LD_LIBRARY_PATH
 export PYTHONPATH=$PWD/../install/python:$PYTHONPATH

--- a/k4ProjectTemplate/CMakeLists.txt
+++ b/k4ProjectTemplate/CMakeLists.txt
@@ -21,7 +21,6 @@ file(GLOB _plugin_sources src/components/*.cpp)
 gaudi_add_module(k4ProjectTemplatePlugins
                  SOURCES ${_plugin_sources}
                  LINK Gaudi::GaudiKernel
-                      Gaudi::GaudiAlgLib
                       k4FWCore::k4FWCore
                       EDM4HEP::edm4hep
                       )

--- a/k4ProjectTemplate/options/createExampleEventData.py
+++ b/k4ProjectTemplate/options/createExampleEventData.py
@@ -18,21 +18,18 @@
 #
 from Gaudi.Configuration import INFO
 from Configurables import CreateExampleEventData
-from Configurables import PodioOutput
-from Configurables import ApplicationMgr
-from Configurables import k4DataSvc
+from k4FWCore import ApplicationMgr
+from k4FWCore import IOSvc
 
-podioevent = k4DataSvc("EventDataSvc")
+iosvc = IOSvc("IOSvc")
+iosvc.output = "output_k4test_exampledata.root"
+iosvc.outputCommands = ["keep *"]
 
 producer = CreateExampleEventData()
 
-out = PodioOutput("out")
-out.filename = "output_k4test_exampledata.root"
-out.outputCommands = ["keep *"]
-
-ApplicationMgr(TopAlg=[producer, out],
+ApplicationMgr(TopAlg=[producer],
                EvtSel="NONE",
                EvtMax=100,
-               ExtSvc=[podioevent],
+               ExtSvc=[iosvc],
                OutputLevel=INFO,
                )

--- a/k4ProjectTemplate/src/components/CreateExampleEventData.cpp
+++ b/k4ProjectTemplate/src/components/CreateExampleEventData.cpp
@@ -18,18 +18,15 @@
  */
 
 #include "Gaudi/Property.h"
-#include "GaudiAlg/Producer.h"
-
-// Define BaseClass_t
-#include "k4FWCore/BaseClass.h"
+#include "k4FWCore/Producer.h"
 
 #include "edm4hep/MCParticleCollection.h"
 
 #include <string>
 
-struct CreateExampleEventData final : Gaudi::Functional::Producer<edm4hep::MCParticleCollection(), BaseClass_t> {
+struct CreateExampleEventData final : k4FWCore::Producer<edm4hep::MCParticleCollection()> {
   CreateExampleEventData(const std::string& name, ISvcLocator* svcLoc)
-      : Producer(name, svcLoc, KeyValue("OutputLocation", "ExampleParticles")) {}
+      : Producer(name, svcLoc, {}, KeyValues("OutputLocation", {"ExampleParticles"})) {}
 
   edm4hep::MCParticleCollection operator()() const override {
     auto coll     = edm4hep::MCParticleCollection();

--- a/k4ProjectTemplate/src/components/ExampleConsumer.cpp
+++ b/k4ProjectTemplate/src/components/ExampleConsumer.cpp
@@ -17,19 +17,18 @@
  * limitations under the License.
  */
 
-#include "Gaudi/Property.h"
-#include "GaudiAlg/Consumer.h"
-
-// Define BaseClass_t
-#include "k4FWCore/BaseClass.h"
+#include "edm4hep/MCParticleCollection.h"
+#include "k4FWCore/Consumer.h"
 
 #include <string>
 
-struct ExampleConsumer final : Gaudi::Functional::Consumer<void(const int&), BaseClass_t> {
+struct ExampleConsumer final : k4FWCore::Consumer<void(const edm4hep::MCParticleCollection&)> {
   ExampleConsumer(const std::string& name, ISvcLocator* svcLoc)
-      : Consumer(name, svcLoc, KeyValue("ExampleConsumerInputLocation", "/ExampleInt")) {}
+      : Consumer(name, svcLoc, {KeyValues("ExampleConsumerInputLocation", {"/ExampleInt"})}) {}
 
-  void operator()(const int& input) const override { info() << "ExampleInt = " << input << endmsg; }
+  void operator()(const edm4hep::MCParticleCollection& input) const override {
+    info() << "ExampleInt = " << input << endmsg;
+  }
 };
 
 DECLARE_COMPONENT(ExampleConsumer)

--- a/k4ProjectTemplate/src/components/ExampleTransformer.cpp
+++ b/k4ProjectTemplate/src/components/ExampleTransformer.cpp
@@ -17,22 +17,24 @@
  * limitations under the License.
  */
 
-#include "Gaudi/Property.h"
-#include "GaudiAlg/Transformer.h"
-
-// Define BaseClass_t
-#include "k4FWCore/BaseClass.h"
+#include "edm4hep/MCParticleCollection.h"
+#include "k4FWCore/Transformer.h"
 
 #include <string>
 
-struct ExampleTransformer final : Gaudi::Functional::Transformer<int(const int&), BaseClass_t> {
+struct ExampleTransformer final
+    : k4FWCore::Transformer<edm4hep::MCParticleCollection(const edm4hep::MCParticleCollection&)> {
   ExampleTransformer(const std::string& name, ISvcLocator* svcLoc)
-      : Transformer(name, svcLoc, KeyValue("ExampleTransformerInputLocation", "/InputExampleInt"),
-                    {KeyValue("ExampleTransformerOutputLocation", "/OutputExampleInt")}) {}
+      : Transformer(name, svcLoc, {KeyValues("ExampleTransformerInputLocation", {"/InputExampleInt"})},
+                    {KeyValues("ExampleTransformerOutputLocation", {"/OutputExampleInt"})}) {}
 
-  int operator()(const int& input) const override {
+  edm4hep::MCParticleCollection operator()(const edm4hep::MCParticleCollection& input) const override {
     info() << "ExampleInt = " << input << endmsg;
-    return input + 1;
+    auto out = edm4hep::MCParticleCollection();
+    for (const auto& mc : input) {
+      out.push_back(mc);
+    }
+    return out;
   }
 };
 


### PR DESCRIPTION
to use the latest version of the algorithms (without compilation warnings) and add a few comments and update the README. Also don't link to GaudiAlgLib, which was causing some problems (with libCLHEP not being found for some reason) when running the steering files after installation.


BEGINRELEASENOTES
- Update algorithms and tests to use the latest version of the algorithms from `k4FWCore` (without compilation warnings) and add a few comments and update the README.
- Don't link to GaudiAlgLib

ENDRELEASENOTES