### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,9 @@ find_package(k4FWCore)
 find_package(Gaudi)
 #---------------------------------------------------------------
 
+include(cmake/Key4hepConfig.cmake)
+
 include(GNUInstallDirs)
-
-# Set up C++ Standard
-# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
-
-if(NOT CMAKE_CXX_STANDARD MATCHES "20|23")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
 
 include(CTest)
 

--- a/k4ProjectTemplate/src/components/HelloWorldAlg.cpp
+++ b/k4ProjectTemplate/src/components/HelloWorldAlg.cpp
@@ -32,7 +32,7 @@ StatusCode HelloWorldAlg::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode HelloWorldAlg::execute(const EventContext& ctx) const {
+StatusCode HelloWorldAlg::execute(const EventContext&) const {
   info() << endmsg;
   info() << endmsg;
   info() << theMessage << endmsg;


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/359.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.
- Fix a warning about an unused variable

ENDRELEASENOTES

In this case the rpath magic is certainly needed as we found out in k4GaudiPandora.