### PR TITLE
Use the properties `Input` and `Output` with `IOSvc`

### DIFF
--- a/k4ProjectTemplate/options/readExampleEventData.py
+++ b/k4ProjectTemplate/options/readExampleEventData.py
@@ -21,7 +21,7 @@ from k4FWCore import ApplicationMgr
 from k4FWCore import IOSvc
 
 iosvc = IOSvc("IOSvc")
-iosvc.input = "output_k4test_exampledata.root"
+iosvc.Input = "output_k4test_exampledata.root"
 
 iosvc.CollectionNames = ["ExampleParticles"]
 


### PR DESCRIPTION
because `input` and `output` have been deprecated for a while. There is a message in the logs when running a steering file saying that they are deprecated but maybe no one noticed.


BEGINRELEASENOTES
- Use the properties `Input` and `Output` with `IOSvc` instead of the deprecated `input` and `output`

ENDRELEASENOTES


See https://github.com/key4hep/k4FWCore/pull/297.